### PR TITLE
Add example for proxy chaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,8 @@ and you can configure it from there.
 
 Alternatively, you can get the proxy JAR from the [downloads](https://papermc.io/downloads/velocity)
 page.
+
+### Proxy chaining
+
+Velocity now includes built-in support for chaining multiple proxies together.
+See `docs/proxy-chaining.md` for configuration details.

--- a/docs/proxy-chaining.md
+++ b/docs/proxy-chaining.md
@@ -1,0 +1,24 @@
+# Proxy Chaining with Velocity
+
+This document describes how to chain multiple Velocity proxies together using the built-in proxy
+chaining support.
+
+## Configuration
+
+Create `proxychain.toml` in your Velocity directory (generated automatically on first run). Define
+each remote proxy under the `[proxies]` section. The key is the name and the value is the
+`host:port` of the next proxy.
+
+Example:
+```toml
+[proxies]
+lobby2 = "127.0.0.1:25566"
+```
+
+Ensure all proxies in the chain share the same `player-info-forwarding-mode` and `forwarding-secret` in
+`velocity.toml`.
+
+## Usage
+
+Use `/chain <proxyName>` in-game to move to another configured proxy. All proxies listed are
+registered automatically on startup and will authenticate using the shared secret.

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -64,6 +64,7 @@ import com.velocitypowered.proxy.scheduler.VelocityScheduler;
 import com.velocitypowered.proxy.server.ServerMap;
 import com.velocitypowered.proxy.util.AddressUtil;
 import com.velocitypowered.proxy.util.ClosestLocaleMatcher;
+import com.velocitypowered.proxy.chain.ProxyChainManager;
 import com.velocitypowered.proxy.util.ResourceUtils;
 import com.velocitypowered.proxy.util.VelocityChannelRegistrar;
 import com.velocitypowered.proxy.util.ratelimit.Ratelimiter;
@@ -170,6 +171,7 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
   private final VelocityScheduler scheduler;
   private final VelocityChannelRegistrar channelRegistrar = new VelocityChannelRegistrar();
   private final ServerListPingHandler serverListPingHandler;
+  private final ProxyChainManager proxyChainManager;
 
   VelocityServer(final ProxyOptions options) {
     pluginManager = new VelocityPluginManager(this);
@@ -181,6 +183,7 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
     servers = new ServerMap(this);
     serverListPingHandler = new ServerListPingHandler(this);
     this.options = options;
+    proxyChainManager = new ProxyChainManager(this, Path.of("."));
   }
 
   public KeyPair getServerKeyPair() {
@@ -301,6 +304,8 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
     commandRateLimiter = Ratelimiters.createWithMilliseconds(configuration.getCommandRatelimit());
     tabCompleteRateLimiter = Ratelimiters.createWithMilliseconds(configuration.getTabCompleteRatelimit());
     loadPlugins();
+
+    eventManager.register(VelocityVirtualPlugin.INSTANCE, proxyChainManager);
 
     // Go ahead and fire the proxy initialization event. We block since plugins should have a chance
     // to fully initialize before we accept any connections to the server.

--- a/proxy/src/main/java/com/velocitypowered/proxy/chain/ProxyChainManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/chain/ProxyChainManager.java
@@ -1,0 +1,130 @@
+package com.velocitypowered.proxy.chain;
+
+import com.electronwill.nightconfig.core.file.CommentedFileConfig;
+import com.google.inject.Inject;
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.connection.PluginMessageEvent;
+import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
+import com.velocitypowered.api.event.player.ServerConnectedEvent;
+import com.velocitypowered.api.plugin.annotation.DataDirectory;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
+import com.velocitypowered.proxy.plugin.virtual.VelocityVirtualPlugin;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import net.kyori.adventure.text.Component;
+
+/**
+ * Built-in manager providing simple proxy chaining support.
+ */
+public class ProxyChainManager {
+  private static final MinecraftChannelIdentifier CHANNEL =
+      MinecraftChannelIdentifier.create("proxychain", "auth");
+
+  private final ProxyServer server;
+  private final Path dataDir;
+  private String secret = "";
+  private final Map<String, String> remotes = new HashMap<>();
+
+  @Inject
+  public ProxyChainManager(ProxyServer server, @DataDirectory Path dataDir) {
+    this.server = server;
+    this.dataDir = dataDir;
+  }
+
+  @Subscribe
+  public void onProxyInit(ProxyInitializeEvent event) {
+    loadConfig();
+    registerServers();
+    registerCommand();
+  }
+
+  @Subscribe
+  public void onServerConnected(ServerConnectedEvent event) {
+    RegisteredServer rs = event.getServer();
+    if (remotes.containsKey(rs.getServerInfo().getName())) {
+      rs.sendPluginMessage(CHANNEL, secret.getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  @Subscribe
+  public void onPluginMessage(PluginMessageEvent event) {
+    if (!event.getIdentifier().equals(CHANNEL)) {
+      return;
+    }
+    if (event.getSource() instanceof Player player) {
+      String received = new String(event.getData(), StandardCharsets.UTF_8);
+      if (!secret.equals(received)) {
+        player.disconnect(Component.text("Invalid proxy chain token"));
+      }
+      event.setResult(PluginMessageEvent.ForwardResult.handled());
+    }
+  }
+
+  private void registerCommand() {
+    server.getCommandManager().register(
+        server.getCommandManager().metaBuilder("chain")
+            .plugin(VelocityVirtualPlugin.INSTANCE)
+            .build(),
+        (invocation) -> {
+          if (!(invocation.source() instanceof Player)) {
+            invocation.source().sendMessage(Component.text("Only players may use this command."));
+            return;
+          }
+          Player player = (Player) invocation.source();
+          if (invocation.arguments().length != 1) {
+            player.sendMessage(Component.text("Usage: /chain <proxy>"));
+            return;
+          }
+          String target = invocation.arguments()[0];
+          RegisteredServer rs = server.getServer(target);
+          if (rs == null) {
+            player.sendMessage(Component.text("Unknown proxy: " + target));
+            return;
+          }
+          player.createConnectionRequest(rs).connect();
+        });
+  }
+
+  private void registerServers() {
+    for (Map.Entry<String, String> e : remotes.entrySet()) {
+      String[] parts = e.getValue().split(":", 2);
+      if (parts.length != 2) continue;
+      try {
+        int port = Integer.parseInt(parts[1]);
+        server.registerServer(
+            new com.velocitypowered.api.proxy.server.ServerInfo(e.getKey(),
+                new java.net.InetSocketAddress(parts[0], port)));
+      } catch (NumberFormatException ex) {
+        // ignore invalid
+      }
+    }
+  }
+
+  private void loadConfig() {
+    Path configPath = dataDir.resolve("proxychain.toml");
+    try (CommentedFileConfig config = CommentedFileConfig.builder(configPath)
+        .defaultData(ProxyChainManager.class.getResource("/default-proxychain.toml"))
+        .autosave()
+        .sync()
+        .build()) {
+      config.load();
+      secret = config.getOrElse("secret", "change_me");
+      Map<String, String> p = config.get("proxies");
+      if (p != null) {
+        remotes.clear();
+        remotes.putAll(p);
+      }
+    }
+  }
+
+  public Set<String> getRemoteNames() {
+    return Collections.unmodifiableSet(remotes.keySet());
+  }
+}

--- a/proxy/src/main/resources/default-proxychain.toml
+++ b/proxy/src/main/resources/default-proxychain.toml
@@ -1,0 +1,4 @@
+secret = "change_me"
+
+[proxies]
+# proxy2 = "127.0.0.1:25566"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,3 +41,4 @@ project(deprecatedConfigurateModule).projectDir = file("proxy/deprecated/configu
 val log4j2ProxyPlugin = ":velocity-proxy-log4j2-plugin"
 include(log4j2ProxyPlugin)
 project(log4j2ProxyPlugin).projectDir = file("proxy/log4j2-plugin")
+


### PR DESCRIPTION
## Summary
- add an example plugin demonstrating chaining between proxies
- document how to configure and use the example
- mention the example in the README

## Testing
- `./gradlew :proxy-chain-example:build` *(fails: No route to host)*