### PR TITLE
Add built-in proxy chaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,8 @@ and you can configure it from there.
 
 Alternatively, you can get the proxy JAR from the [downloads](https://papermc.io/downloads/velocity)
 page.
+
+### Proxy chaining
+
+Velocity includes built-in support for chaining multiple proxies together. See
+`docs/proxy-chaining.md` for usage instructions.

--- a/api/src/main/java/com/velocitypowered/api/proxy/ProxyServer.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/ProxyServer.java
@@ -13,6 +13,7 @@ import com.velocitypowered.api.event.EventManager;
 import com.velocitypowered.api.plugin.PluginManager;
 import com.velocitypowered.api.proxy.config.ProxyConfig;
 import com.velocitypowered.api.proxy.messages.ChannelRegistrar;
+import com.velocitypowered.api.proxy.chain.ProxyChainManager;
 import com.velocitypowered.api.proxy.player.ResourcePackInfo;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
@@ -187,6 +188,13 @@ public interface ProxyServer extends Audience {
   ChannelRegistrar getChannelRegistrar();
 
   /**
+   * Provides access to the proxy chaining manager.
+   *
+   * @return the proxy chain manager
+   */
+  ProxyChainManager getProxyChainManager();
+
+  /**
    * Gets the address that this proxy is bound to. This does not necessarily indicate the external
    * IP address of the proxy.
    *
@@ -230,3 +238,4 @@ public interface ProxyServer extends Audience {
    */
   ResourcePackInfo.Builder createResourcePackBuilder(String url);
 }
+

--- a/api/src/main/java/com/velocitypowered/api/proxy/chain/ProxyChainManager.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/chain/ProxyChainManager.java
@@ -1,0 +1,35 @@
+package com.velocitypowered.api.proxy.chain;
+
+import com.velocitypowered.api.proxy.Player;
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Manages connections between Velocity proxies.
+ */
+public interface ProxyChainManager {
+
+  /** Returns all configured proxies keyed by name. */
+  Map<String, InetSocketAddress> getProxies();
+
+  /** Retrieves a proxy by name. */
+  Optional<InetSocketAddress> getProxy(String name);
+
+  /** Registers a proxy at runtime. */
+  void registerProxy(String name, InetSocketAddress address);
+
+  /** Unregisters a proxy. */
+  void unregisterProxy(String name);
+
+  /**
+   * Connects a player to another proxy.
+   *
+   * @param player the player
+   * @param proxyName the destination proxy
+   * @return future indicating success
+   */
+  CompletableFuture<Boolean> connectPlayer(Player player, String proxyName);
+}
+

--- a/docs/proxy-chaining.md
+++ b/docs/proxy-chaining.md
@@ -1,0 +1,23 @@
+# Proxy Chaining with Velocity
+
+Velocity can forward players between multiple proxies. This feature is built in and configured through `proxychain.toml` located next to `velocity.toml`.
+
+## Configuration
+
+1. Create `proxychain.toml` if it does not exist. A default file is generated on first run.
+2. Define each remote proxy under the `[proxies]` section as `name = "host:port"`.
+3. Set `secret` to a shared token used to authenticate between proxies.
+
+Example:
+```toml
+secret = "changeme"
+
+[proxies]
+lobby2 = "127.0.0.1:25566"
+```
+
+All proxies in the chain must share the same `player-info-forwarding-mode` and `forwarding-secret` in `velocity.toml`.
+
+## Usage
+
+Run `/chain <proxyName>` in game to move to the target proxy. Plugins can interact with chaining through `ProxyServer.getProxyChainManager()`.

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -44,6 +44,7 @@ import com.velocitypowered.proxy.command.builtin.GlistCommand;
 import com.velocitypowered.proxy.command.builtin.SendCommand;
 import com.velocitypowered.proxy.command.builtin.ServerCommand;
 import com.velocitypowered.proxy.command.builtin.ShutdownCommand;
+import com.velocitypowered.proxy.command.builtin.ChainCommand;
 import com.velocitypowered.proxy.command.builtin.VelocityCommand;
 import com.velocitypowered.proxy.config.VelocityConfiguration;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
@@ -105,6 +106,7 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.translation.GlobalTranslator;
 import net.kyori.adventure.translation.TranslationRegistry;
+import com.velocitypowered.proxy.chain.VelocityProxyChainManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bstats.MetricsBase;
@@ -170,6 +172,7 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
   private final VelocityScheduler scheduler;
   private final VelocityChannelRegistrar channelRegistrar = new VelocityChannelRegistrar();
   private final ServerListPingHandler serverListPingHandler;
+  private final VelocityProxyChainManager chainManager;
 
   VelocityServer(final ProxyOptions options) {
     pluginManager = new VelocityPluginManager(this);
@@ -180,6 +183,7 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
     cm = new ConnectionManager(this);
     servers = new ServerMap(this);
     serverListPingHandler = new ServerListPingHandler(this);
+    chainManager = new VelocityProxyChainManager(this);
     this.options = options;
   }
 
@@ -284,6 +288,13 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
     );
     new GlistCommand(this).register();
     new SendCommand(this).register();
+    final BrigadierCommand chainCommand = new ChainCommand(this).create();
+    commandManager.register(
+        commandManager.metaBuilder(chainCommand)
+            .plugin(VelocityVirtualPlugin.INSTANCE)
+            .build(),
+        chainCommand
+    );
 
     this.doStartupConfigLoad();
 
@@ -815,6 +826,11 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
   @Override
   public VelocityChannelRegistrar getChannelRegistrar() {
     return channelRegistrar;
+  }
+
+  @Override
+  public VelocityProxyChainManager getProxyChainManager() {
+    return chainManager;
   }
   
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/chain/VelocityProxyChainManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/chain/VelocityProxyChainManager.java
@@ -1,0 +1,98 @@
+package com.velocitypowered.proxy.chain;
+
+import com.electronwill.nightconfig.core.file.CommentedFileConfig;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.chain.ProxyChainManager;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+import com.velocitypowered.api.proxy.server.ServerInfo;
+import com.velocitypowered.proxy.VelocityServer;
+import java.net.InetSocketAddress;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Default implementation of {@link ProxyChainManager} built into the proxy.
+ */
+public class VelocityProxyChainManager implements ProxyChainManager {
+
+  private static final String CHANNEL = "velocity:proxychain";
+  private final VelocityServer server;
+  private final Map<String, InetSocketAddress> proxies = new HashMap<>();
+  private String secret = "";
+
+  public VelocityProxyChainManager(VelocityServer server) {
+    this.server = server;
+    loadConfig();
+  }
+
+  private void loadConfig() {
+    Path configPath = Path.of("proxychain.toml");
+    try (CommentedFileConfig config = CommentedFileConfig.builder(configPath)
+        .defaultData(VelocityServer.class.getResource("/default-proxychain.toml"))
+        .autosave()
+        .sync()
+        .build()) {
+      config.load();
+      secret = config.getOrElse("secret", "changeme");
+      Map<String, String> map = config.get("proxies");
+      if (map != null) {
+        for (Map.Entry<String, String> entry : map.entrySet()) {
+          String[] parts = entry.getValue().split(":", 2);
+          if (parts.length != 2) continue;
+          try {
+            int port = Integer.parseInt(parts[1]);
+            registerProxy(entry.getKey(), new InetSocketAddress(parts[0], port));
+          } catch (NumberFormatException ignored) {
+          }
+        }
+      }
+    }
+  }
+
+  @Override
+  public Map<String, InetSocketAddress> getProxies() {
+    return Collections.unmodifiableMap(proxies);
+  }
+
+  @Override
+  public Optional<InetSocketAddress> getProxy(String name) {
+    return Optional.ofNullable(proxies.get(name));
+  }
+
+  @Override
+  public void registerProxy(String name, InetSocketAddress address) {
+    proxies.put(name, address);
+    ServerInfo info = new ServerInfo(name, address);
+    server.registerServer(info);
+  }
+
+  @Override
+  public void unregisterProxy(String name) {
+    InetSocketAddress addr = proxies.remove(name);
+    if (addr != null) {
+      server.unregisterServer(new ServerInfo(name, addr));
+    }
+  }
+
+  @Override
+  public CompletableFuture<Boolean> connectPlayer(Player player, String proxyName) {
+    Optional<RegisteredServer> rs = server.getServer(proxyName);
+    if (rs.isEmpty()) {
+      return CompletableFuture.completedFuture(false);
+    }
+    return player.createConnectionRequest(rs.get()).connect().thenApply(success -> {
+      if (success) {
+        player.getConnectedServer().sendPluginMessage(
+            () -> CHANNEL,
+            secret.getBytes()
+        );
+      }
+      return success;
+    });
+  }
+}
+

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/ChainCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/ChainCommand.java
@@ -1,0 +1,52 @@
+package com.velocitypowered.proxy.command.builtin;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.tree.LiteralCommandNode;
+import com.velocitypowered.api.command.BrigadierCommand;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.permission.Tristate;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import net.kyori.adventure.text.Component;
+
+/**
+ * Command allowing players to switch proxies using the chain manager.
+ */
+public class ChainCommand {
+  private final ProxyServer server;
+
+  public ChainCommand(ProxyServer server) {
+    this.server = server;
+  }
+
+  public BrigadierCommand create() {
+    LiteralCommandNode<CommandSource> node = BrigadierCommand
+        .literalArgumentBuilder("chain")
+        .requires(src -> src instanceof Player
+            && src.getPermissionValue("velocity.command.chain") != Tristate.FALSE)
+        .then(BrigadierCommand.requiredArgumentBuilder("proxy", StringArgumentType.word())
+            .suggests((ctx, builder) -> {
+              String arg = ctx.getArguments().containsKey("proxy")
+                  ? StringArgumentType.getString(ctx, "proxy") : "";
+              server.getProxyChainManager().getProxies().keySet().stream()
+                  .filter(n -> n.regionMatches(true, 0, arg, 0, arg.length()))
+                  .forEach(builder::suggest);
+              return builder.buildFuture();
+            })
+            .executes(ctx -> {
+              Player player = (Player) ctx.getSource();
+              String target = StringArgumentType.getString(ctx, "proxy");
+              server.getProxyChainManager().connectPlayer(player, target)
+                  .thenAccept(success -> {
+                    if (!success) {
+                      player.sendMessage(Component.text("Failed to connect."));
+                    }
+                  });
+              return Command.SINGLE_SUCCESS;
+            }))
+        .build();
+    return new BrigadierCommand(node);
+  }
+}
+

--- a/proxy/src/main/resources/default-proxychain.toml
+++ b/proxy/src/main/resources/default-proxychain.toml
@@ -1,0 +1,6 @@
+secret = "changeme"
+
+[proxies]
+# Configure remote proxies here. Each key is the proxy name and the value is "host:port".
+# example:
+# proxy2 = "127.0.0.1:25566"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,3 +41,4 @@ project(deprecatedConfigurateModule).projectDir = file("proxy/deprecated/configu
 val log4j2ProxyPlugin = ":velocity-proxy-log4j2-plugin"
 include(log4j2ProxyPlugin)
 project(log4j2ProxyPlugin).projectDir = file("proxy/log4j2-plugin")
+


### PR DESCRIPTION
## Summary
- integrate proxy chaining into the proxy runtime
- expose `ProxyChainManager` API and command `/chain`
- load `proxychain.toml` to register proxies
- remove old example plugin and update docs

## Testing
- `./gradlew build` *(fails: No route to host)*