### PR TITLE
Add built‑in proxy chaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,8 @@ and you can configure it from there.
 
 Alternatively, you can get the proxy JAR from the [downloads](https://papermc.io/downloads/velocity)
 page.
+
+### Proxy chaining
+
+Velocity includes optional support for chaining multiple proxy instances together.
+Configuration and usage is documented in `docs/proxy-chaining.md`.

--- a/api/src/main/java/com/velocitypowered/api/proxy/ProxyServer.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/ProxyServer.java
@@ -209,6 +209,15 @@ public interface ProxyServer extends Audience {
   ProxyVersion getVersion();
 
   /**
+   * Obtains the {@link com.velocitypowered.api.proxy.chain.ProxyChainManager} instance
+   * used to manage chained proxies.
+   *
+   * @return the proxy chain manager
+   * @since 3.3.0
+   */
+  com.velocitypowered.api.proxy.chain.ProxyChainManager getProxyChainManager();
+
+  /**
    * Creates a builder to build a {@link ResourcePackInfo} instance for use with
    * {@link com.velocitypowered.api.proxy.Player#sendResourcePackOffer(ResourcePackInfo)}.
    *

--- a/api/src/main/java/com/velocitypowered/api/proxy/chain/ProxyChainManager.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/chain/ProxyChainManager.java
@@ -1,0 +1,44 @@
+package com.velocitypowered.api.proxy.chain;
+
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Provides facilities for chaining multiple Velocity proxies.
+ */
+public interface ProxyChainManager {
+
+  /**
+   * Registers a new proxy in the chain.
+   *
+   * @param name the proxy name
+   * @param address the proxy address
+   */
+  void registerProxy(String name, InetSocketAddress address);
+
+  /**
+   * Retrieves a registered proxy by name.
+   *
+   * @param name the proxy name
+   * @return the server representing the proxy, if registered
+   */
+  Optional<RegisteredServer> getProxy(String name);
+
+  /**
+   * Returns an immutable view of all registered proxies.
+   *
+   * @return the proxy map
+   */
+  Map<String, RegisteredServer> getAllProxies();
+
+  /**
+   * Connects the specified player to the named proxy.
+   *
+   * @param player the player
+   * @param proxyName the target proxy name
+   */
+  void connect(Player player, String proxyName);
+}

--- a/docs/proxy-chaining.md
+++ b/docs/proxy-chaining.md
@@ -1,0 +1,23 @@
+# Proxy Chaining with Velocity
+
+Velocity can forward players between multiple proxy instances. Configuration is stored in `proxychain.toml` next to `velocity.toml`.
+
+## Configuration
+
+1. On first run a `proxychain.toml` file is created using `default-proxychain.toml`.
+2. Set a shared `secret` on all proxies.
+3. List remote proxies under `[proxies]` using `name = "host:port"` pairs.
+
+Example:
+```toml
+secret = "change_me"
+[proxies]
+lobby2 = "127.0.0.1:25566"
+```
+
+## Usage
+
+Players can use `/chain <proxy>` to move between proxies. Plugins may access
+`ProxyServer.getProxyChainManager()` to programmatically connect players.
+The manager sends a short authentication token to verify transitions.
+

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -44,6 +44,7 @@ import com.velocitypowered.proxy.command.builtin.GlistCommand;
 import com.velocitypowered.proxy.command.builtin.SendCommand;
 import com.velocitypowered.proxy.command.builtin.ServerCommand;
 import com.velocitypowered.proxy.command.builtin.ShutdownCommand;
+import com.velocitypowered.proxy.command.builtin.ChainCommand;
 import com.velocitypowered.proxy.command.builtin.VelocityCommand;
 import com.velocitypowered.proxy.config.VelocityConfiguration;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
@@ -170,6 +171,7 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
   private final VelocityScheduler scheduler;
   private final VelocityChannelRegistrar channelRegistrar = new VelocityChannelRegistrar();
   private final ServerListPingHandler serverListPingHandler;
+  private final com.velocitypowered.proxy.chain.VelocityProxyChainManager proxyChainManager;
 
   VelocityServer(final ProxyOptions options) {
     pluginManager = new VelocityPluginManager(this);
@@ -180,6 +182,7 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
     cm = new ConnectionManager(this);
     servers = new ServerMap(this);
     serverListPingHandler = new ServerListPingHandler(this);
+    proxyChainManager = new com.velocitypowered.proxy.chain.VelocityProxyChainManager(this, Path.of("."));
     this.options = options;
   }
 
@@ -284,8 +287,10 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
     );
     new GlistCommand(this).register();
     new SendCommand(this).register();
+    new com.velocitypowered.proxy.command.builtin.ChainCommand(this).register();
 
     this.doStartupConfigLoad();
+    proxyChainManager.loadConfig();
 
     for (ServerInfo cliServer : options.getServers()) {
       servers.register(cliServer);
@@ -815,6 +820,11 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
   @Override
   public VelocityChannelRegistrar getChannelRegistrar() {
     return channelRegistrar;
+  }
+
+  @Override
+  public com.velocitypowered.api.proxy.chain.ProxyChainManager getProxyChainManager() {
+    return proxyChainManager;
   }
   
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/chain/VelocityProxyChainManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/chain/VelocityProxyChainManager.java
@@ -1,0 +1,139 @@
+package com.velocitypowered.proxy.chain;
+
+import com.electronwill.nightconfig.core.file.CommentedFileConfig;
+import com.google.inject.Inject;
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.connection.PluginMessageEvent;
+import com.velocitypowered.api.event.player.PostLoginEvent;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+import com.velocitypowered.api.proxy.server.ServerInfo;
+import com.velocitypowered.proxy.VelocityServer;
+import com.velocitypowered.proxy.plugin.virtual.VelocityVirtualPlugin;
+import java.net.InetSocketAddress;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import net.kyori.adventure.text.Component;
+
+/**
+ * Default implementation of proxy chaining support.
+ */
+public class VelocityProxyChainManager implements com.velocitypowered.api.proxy.chain.ProxyChainManager {
+
+  private static final MinecraftChannelIdentifier CHANNEL =
+      MinecraftChannelIdentifier.create("proxychain", "auth");
+
+  private final VelocityServer server;
+  private String secret = "change_me";
+  private final Map<String, RegisteredServer> proxies = new HashMap<>();
+  private final Map<UUID, Boolean> authenticated = new HashMap<>();
+  private final Path dataDirectory;
+
+  @Inject
+  public VelocityProxyChainManager(VelocityServer server, Path dataDirectory) {
+    this.server = server;
+    this.dataDirectory = dataDirectory;
+  }
+
+  /** Loads the proxy chain configuration and registers proxies. */
+  public void loadConfig() {
+    Path configPath = dataDirectory.resolve("proxychain.toml");
+    try (CommentedFileConfig config = CommentedFileConfig.builder(configPath)
+        .defaultData(VelocityProxyChainManager.class.getResource("/default-proxychain.toml"))
+        .autosave()
+        .sync()
+        .build()) {
+      config.load();
+      this.secret = config.getOrElse("secret", "change_me");
+      Map<String, String> confProxies = config.get("proxies");
+      if (confProxies != null) {
+        for (Map.Entry<String, String> e : confProxies.entrySet()) {
+          String[] parts = e.getValue().split(":", 2);
+          if (parts.length != 2) continue;
+          try {
+            int port = Integer.parseInt(parts[1]);
+            registerProxy(e.getKey(), new InetSocketAddress(parts[0], port));
+          } catch (NumberFormatException ignore) {
+          }
+        }
+      }
+    }
+  }
+
+  @Override
+  public void registerProxy(String name, InetSocketAddress address) {
+    ServerInfo info = new ServerInfo(name, address);
+    RegisteredServer rs = server.registerServer(info);
+    proxies.put(name, rs);
+  }
+
+  @Override
+  public Optional<RegisteredServer> getProxy(String name) {
+    return Optional.ofNullable(proxies.get(name));
+  }
+
+  @Override
+  public Map<String, RegisteredServer> getAllProxies() {
+    return Collections.unmodifiableMap(proxies);
+  }
+
+  @Override
+  public void connect(Player player, String proxyName) {
+    Optional<RegisteredServer> target = getProxy(proxyName);
+    if (target.isEmpty()) {
+      player.sendMessage(Component.text("Unknown proxy: " + proxyName));
+      return;
+    }
+    player.createConnectionRequest(target.get()).connect().whenComplete((res, ex) -> {
+      if (ex != null || res == null || res.getStatus() != com.velocitypowered.api.proxy.ConnectionRequestBuilder.Status.SUCCESS) {
+        player.sendMessage(Component.text("Failed to connect"));
+        return;
+      }
+      byte[] token = generateToken(player.getUniqueId());
+      player.sendPluginMessage(CHANNEL, token);
+    });
+  }
+
+  private byte[] generateToken(UUID uuid) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      digest.update(secret.getBytes());
+      digest.update(uuid.toString().getBytes());
+      return digest.digest();
+    } catch (NoSuchAlgorithmException e) {
+      return uuid.toString().getBytes();
+    }
+  }
+
+  @Subscribe
+  public void onPostLogin(PostLoginEvent event) {
+    authenticated.put(event.getPlayer().getUniqueId(), Boolean.FALSE);
+    server.getScheduler().buildTask(VelocityVirtualPlugin.INSTANCE, () -> {
+      if (!Boolean.TRUE.equals(authenticated.get(event.getPlayer().getUniqueId()))) {
+        event.getPlayer().disconnect(Component.text("Proxy chain authentication failed"));
+      }
+      authenticated.remove(event.getPlayer().getUniqueId());
+    }).delay(20L).schedule();
+  }
+
+  @Subscribe
+  public void onPluginMessage(PluginMessageEvent event) {
+    if (!event.getIdentifier().equals(CHANNEL)) {
+      return;
+    }
+    if (!(event.getSource() instanceof Player player)) {
+      return;
+    }
+    byte[] expected = generateToken(player.getUniqueId());
+    if (MessageDigest.isEqual(expected, event.getData())) {
+      authenticated.put(player.getUniqueId(), Boolean.TRUE);
+    }
+  }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/ChainCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/ChainCommand.java
@@ -1,0 +1,61 @@
+package com.velocitypowered.proxy.command.builtin;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.builder.RequiredArgumentBuilder;
+import com.velocitypowered.api.command.BrigadierCommand;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.permission.Tristate;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.proxy.command.builtin.CommandMessages;
+import com.velocitypowered.proxy.plugin.virtual.VelocityVirtualPlugin;
+
+/**
+ * Command used to forward players to another proxy in the chain.
+ */
+public class ChainCommand {
+  private final ProxyServer server;
+
+  public ChainCommand(ProxyServer server) {
+    this.server = server;
+  }
+
+  public void register() {
+    LiteralArgumentBuilder<CommandSource> root = BrigadierCommand
+        .literalArgumentBuilder("chain")
+        .requires(src -> src.getPermissionValue("velocity.command.chain") == Tristate.TRUE);
+
+    RequiredArgumentBuilder<CommandSource, String> proxyArg = BrigadierCommand
+        .requiredArgumentBuilder("proxy", StringArgumentType.word())
+        .suggests((ctx, builder) -> {
+          String arg = ctx.getArguments().containsKey("proxy")
+              ? ctx.getArgument("proxy", String.class) : "";
+          for (String name : server.getProxyChainManager().getAllProxies().keySet()) {
+            if (name.regionMatches(true, 0, arg, 0, arg.length())) {
+              builder.suggest(name);
+            }
+          }
+          return builder.buildFuture();
+        })
+        .executes(ctx -> {
+          if (!(ctx.getSource() instanceof Player)) {
+            ctx.getSource().sendMessage(CommandMessages.PLAYERS_ONLY);
+            return 0;
+          }
+          Player player = (Player) ctx.getSource();
+          String target = ctx.getArgument("proxy", String.class);
+          server.getProxyChainManager().connect(player, target);
+          return Command.SINGLE_SUCCESS;
+        });
+
+    root.then(proxyArg);
+    BrigadierCommand command = new BrigadierCommand(root);
+    server.getCommandManager().register(
+        server.getCommandManager().metaBuilder(command)
+            .plugin(VelocityVirtualPlugin.INSTANCE)
+            .build(),
+        command);
+  }
+}

--- a/proxy/src/main/resources/default-proxychain.toml
+++ b/proxy/src/main/resources/default-proxychain.toml
@@ -1,0 +1,5 @@
+# Default configuration for built-in proxy chaining
+secret = "change_me"
+
+[proxies]
+# lobby2 = "127.0.0.1:25566"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,3 +41,4 @@ project(deprecatedConfigurateModule).projectDir = file("proxy/deprecated/configu
 val log4j2ProxyPlugin = ":velocity-proxy-log4j2-plugin"
 include(log4j2ProxyPlugin)
 project(log4j2ProxyPlugin).projectDir = file("proxy/log4j2-plugin")
+


### PR DESCRIPTION
## Summary
- remove old proxy chain example plugin
- implement `ProxyChainManager` API and Velocity implementation
- register chain command and load proxychain configuration at startup
- document configuration for chaining

## Testing
- `./gradlew build` *(fails: No route to host)*